### PR TITLE
Tr doc edits

### DIFF
--- a/How_to_contribute/1_suggested_setup.adoc
+++ b/How_to_contribute/1_suggested_setup.adoc
@@ -47,7 +47,7 @@ If you do not have any of the software or accounts listed in the section above, 
 
 1. Create a GitHub account. See the link:3_github_help.adoc[GitHub Help] file.
 2. Install Git. See the link:4_git_help.adoc[Git Help] file.
-3. Install AsciidocFX or Atom or Brackets and the necessary packages or extensions to read `.adoc` and `.md` files. See link:5_plane_text_editor_help.adoc[Text editors/IDEs help] file.
+3. Install AsciidocFX or Atom or Brackets and the necessary packages or extensions to read `.adoc` and `.md` files. See link:5_plain_text_editor_help.adoc[Text editors/IDEs help] file.
 4. Learn a little about AsciiDoc markup. See the link:asciidoc_help.adoc[AsciiDoc Help] file. +
 {empty} +
 

--- a/How_to_contribute/1_suggested_setup.adoc
+++ b/How_to_contribute/1_suggested_setup.adoc
@@ -51,4 +51,5 @@ If you do not have any of the software or accounts listed in the section above, 
 4. Learn a little about AsciiDoc markup. See the link:asciidoc_help.adoc[AsciiDoc Help] file. +
 {empty} +
 
+
 Next: link:2_suggested_workflow.adoc[Suggested workflow to contribute to the ICES WGFAST convention documents]


### PR DESCRIPTION
Typo in document 1_suggested_setup.adoc meant link to 5_plain_text_editor_help.adoc did not work. Working through Erin's excellent documentation allowed me to fix this typo and get to this point of creating pull request. 